### PR TITLE
init option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ onNoneSelected(masterCheckbox, slaveCheckboxes)
 
 	Callback, that is called, when none of the checkboxes is selected
 
+init: true/false
+
+	You can decide whether you want to call callback function during initialization or not. Default value is true.
+
 ## License 
 
 (The MIT License)

--- a/lib/jquery.checkboxgroup.js
+++ b/lib/jquery.checkboxgroup.js
@@ -15,7 +15,7 @@
 				onNoneHandler = options.onNoneSelected || function() {},
 				onSomeHandler = options.onSomeSelected || function() {},
 				onAllHandler = options.onAllSelected || function() {},
-				initialize = options.init || true;
+				initialize = options.init !== undefined ? options.init : true;
 
 			var check = function() {
 				var checked = slaves.filter(':checked'),

--- a/lib/jquery.checkboxgroup.js
+++ b/lib/jquery.checkboxgroup.js
@@ -14,7 +14,8 @@
 				numSlaves = slaves.length,
 				onNoneHandler = options.onNoneSelected || function() {},
 				onSomeHandler = options.onSomeSelected || function() {},
-				onAllHandler = options.onAllSelected || function() {};
+				onAllHandler = options.onAllSelected || function() {},
+				initialize = options.init || true;
 
 			var check = function() {
 				var checked = slaves.filter(':checked'),
@@ -35,7 +36,10 @@
 				}
 			}
 			slaves.change(check);
-			check();
+			
+			if(initialize){
+				check();
+			}
 
 			master.click(function() {
 				master.css('opacity', 1);


### PR DESCRIPTION
Now you can decide whether you want to initialize your checkboxgroup or not. Really useful when you don't want to trigger handlers when initializing with checkboxGroup()
